### PR TITLE
main: get font paths using fontconfig and make Makefile more packager friendly

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Dependencies
         run: |
           apt-get update
-          apt-get install -y build-essential libsdl2-dev libsdl2-ttf-dev libx11-dev checkinstall
+          apt-get install -y build-essential pkg-config libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libx11-dev checkinstall
 
       - name: Build the Application
         run: make

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,32 @@
-CXX = g++
-CXXFLAGS = -std=c++11 -O2 -Iinclude
-LIBS = -lSDL2 -lSDL2_ttf -lX11 -pthread
+override PREFIX ?= /usr/local
 
-SRC = src/main.cpp src/timer.cpp src/hotkeys.cpp
-OBJ = $(SRC:.cpp=.o)
+override CXX ?= g++
+
+override LIBS ?= sdl2 SDL2_ttf x11 fontconfig
+
+override CXXFLAGS ?= -O2 -Wall -Wextra -Werror
+override CXXFLAGS += -std=c++11 -Iinclude $(shell pkg-config --cflags $(LIBS))
+
+LD_FLAGS := $(shell pkg-config --libs-only-L $(LIBS))
+LD_LIBS := $(shell pkg-config --libs-only-l $(LIBS)) -lstdc++ -pthread
+
+SRC := src/main.cpp src/timer.cpp src/hotkeys.cpp
+OBJ := $(SRC:.cpp=.o)
 
 all: simplefuckingtimer
 
 simplefuckingtimer: $(OBJ)
-	$(CXX) $(CXXFLAGS) -o $@ $(OBJ) $(LIBS)
-
-src/%.o: src/%.cpp
-	$(CXX) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(LD_FLAGS) -o $@ $(OBJ) $(LD_LIBS)
 
 clean:
 	rm -f $(OBJ) simplefuckingtimer
 
 install: simplefuckingtimer
-	@echo "Installing simplefuckingtimer to /usr/local/bin..."
-	install -Dm755 simplefuckingtimer /usr/local/bin/simplefuckingtimer
-	@echo "Installing icon to /usr/share/pixmaps..."
-	install -Dm644 assets/sft-logo-256.png /usr/share/pixmaps/sft-logo-256.png
-	@echo "Installing desktop file to /usr/share/applications..."
-	install -Dm644 simplefuckingtimer.desktop /usr/share/applications/simplefuckingtimer.desktop
+	install -Dm755 simplefuckingtimer $(DESTDIR)$(PREFIX)/bin/simplefuckingtimer
+	install -Dm644 assets/sft-logo-256.png $(DESTDIR)$(PREFIX)/share/pixmaps/sft-logo-256.png
+	install -Dm644 simplefuckingtimer.desktop $(DESTDIR)$(PREFIX)/share/applications/simplefuckingtimer.desktop
 
 uninstall:
-	@echo "Removing simplefuckingtimer from /usr/local/bin..."
-	rm -f /usr/local/bin/simplefuckingtimer
-	@echo "Removing icon from /usr/share/pixmaps..."
-	rm -f /usr/share/pixmaps/sft-logo-256.png
-	@echo "Removing desktop file from /usr/share/applications..."
-	rm -f /usr/share/applications/simplefuckingtimer.desktop
-
+	rm -f $(DESTDIR)$(PREFIX)/bin/simplefuckingtimer
+	rm -f $(DESTDIR)$(PREFIX)/share/pixmaps/sft-logo-256.png
+	rm -f $(DESTDIR)$(PREFIX)/share/applications/simplefuckingtimer.desktop

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A minimal overlay timer for speedrunning with global hotkeys on Linux.
 Install necessary packages:
 ~~~bash
 sudo apt update
-sudo apt install build-essential libsdl2-dev libsdl2-ttf-dev libx11-dev
+sudo apt install build-essential pkg-config libsdl2-dev libsdl2-ttf-dev libx11-dev libfontconfig-dev
 ~~~
 
 Build then install:

--- a/guix.scm
+++ b/guix.scm
@@ -1,0 +1,34 @@
+(use-modules (guix git)
+             (guix gexp)
+             (guix packages)
+             (guix licenses)
+             (guix build-system gnu)
+             (gnu packages)
+             (gnu packages fontutils)
+             (gnu packages guile)
+             (gnu packages pkg-config)
+             (gnu packages sdl)
+             (gnu packages texinfo)
+             (gnu packages xorg))
+
+(package
+  (name "simplefuckingtimer")
+  (version "0")
+  (source
+   (local-file (dirname (current-filename))
+               #:recursive? #t))
+  (build-system gnu-build-system)
+  (arguments
+   '(#:phases (modify-phases %standard-phases
+                (delete 'configure)
+                (delete 'check))
+     #:make-flags (list (string-append "PREFIX="
+                                       (assoc-ref %outputs "out")))))
+  (native-inputs (list pkg-config))
+  (inputs (list sdl2 sdl2-ttf fontconfig libx11))
+  (synopsis
+   "Minimal overlay timer for speedrunning with global hotkeys on Linux")
+  (description
+   "Minimal timer for speedrunning on Linux. Start, Stop, Reset/Revert, Pause/Resume. Always on Top. Global Hotkeys. That's it.")
+  (home-page "https://github.com/yetanotherf0rked/simplefuckingtimer")
+  (license expat))

--- a/simplefuckingtimer.desktop
+++ b/simplefuckingtimer.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Simple Fucking Timer
 Comment=A minimal overlay timer for speedrunning with global hotkeys on Linux.
-Exec=/usr/local/bin/simplefuckingtimer
+Exec=simplefuckingtimer
 Icon=sft-logo-256
 Terminal=false
 Type=Application

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <fontconfig/fontconfig.h>
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
 #include <unistd.h>
@@ -56,18 +57,39 @@ std::string formatTime(double seconds) {
 
 // Helper function to search for a system default font.
 std::string getDefaultFontPath() {
-    std::vector<std::string> possiblePaths = {
-        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
-        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
-        "/usr/share/fonts/truetype/freefont/FreeSans.ttf"
-    };
+  std::vector<std::string> validFonts = {"DejaVuSans", "LiberationSans",
+                                         "FreeSans"};
 
-    for (const auto &path : possiblePaths) {
-        if (access(path.c_str(), F_OK) == 0) {
-            return path;
-        }
+  FcConfig *conf = FcInitLoadConfigAndFonts();
+
+  for (const auto &fontName : validFonts) {
+    FcPattern *pat = FcNameParse((FcChar8 *)&fontName);
+
+    FcConfigSubstitute(conf, pat, FcMatchPattern);
+    FcDefaultSubstitute(pat);
+
+    FcResult result;
+    FcFontSet *font_patterns = FcFontSort(conf, pat, FcTrue, 0, &result);
+
+    if (!font_patterns || font_patterns->nfont == 0) {
+      fprintf(stderr, "Fontconfig could not find ANY fonts on the system?\n");
+      break;
     }
-    return "";
+
+    FcPattern *font_pattern = FcFontRenderPrepare(conf, pat, font_patterns->fonts[0]);
+
+    FcChar8 *value;
+    FcResult pattern_as_string =
+        FcPatternGetString(font_pattern, FC_FILE, 0, &value);
+
+    FcFontSetSortDestroy(font_patterns);
+    FcPatternDestroy(pat);
+
+    if (pattern_as_string != FcResultMatch)
+      continue;
+    return reinterpret_cast<const char *>(value);
+  }
+  return "";
 }
 
 // Global variables for overlay sizing and margins.
@@ -115,7 +137,7 @@ void renderTimer(SDL_Renderer* renderer, TTF_Font* font, double timeValue) {
 }
 
 
-int main(int argc, char* argv[]) {
+int main(void) {
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
         std::cerr << "SDL_Init Error: " << SDL_GetError() << "\n";
         return 1;


### PR DESCRIPTION
By using fontconfig the program can find a font without hardcoding paths
which only work on some distros, but not others.

In addition, the Makefile is changed to allow for easier building and
changing where the package is installed.

Lastly, add a guix.scm file for easier development and as a proof of
concept on how to package simplefuckingtimer for distros.

---

I know this is a lot of changes and not all are necessary, so feel free
to only pick what you think is best.

I tried to keep the build system to one makefile, but of course the C++
world has a lot of opinions on this.

Shoutout to Eli Schwartz in particular for making a version with
autoconf
https://paste.xinu.at/eh8kfH/

I don't really feel comfortable enough with autoconf to use that one,
but feel free to use it.

Lastly, I also got it to build with void's build system with the
following template (also as a proof of concept, but also because void is
what I use)

This doesn't make sense to have in this repo, but it's a good point of
reference for how the program can be packaged in other distros.

```sh
# Template file for 'simplefuckingtimer'
pkgname=simplefuckingtimer
version=0
revision=1
build_style=gnu-makefile
hostmakedepends="pkg-config"
makedepends="SDL2-devel SDL2_ttf-devel libX11-devel fontconfig-devel"
short_desc="Minimal timer for speedrunning on Linux. Start, Stop, Reset and Pause"
maintainer="Luca Matei Pintilie <luca@lucamatei.com>"
license="MIT"
homepage="https://github.com/yetanotherf0rked/simplefuckingtimer"
distfiles="https://github.com/AnInternetTroll/simplefuckingtimer/archive/refs/heads/user/luca/fonts-and-linux.tar.gz"
checksum=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```
